### PR TITLE
[Design] body 테두리에 남는 여백 제거

### DIFF
--- a/IFU-Web/src/app/app.component.scss
+++ b/IFU-Web/src/app/app.component.scss
@@ -79,6 +79,7 @@ body {
 .bif-section {
   width: 100%;
   box-sizing: border-box;
+  height: 100%;
 
   h1 {
     font-size: 2rem;
@@ -122,6 +123,7 @@ main {
   display: flex;
   justify-content: space-around;
   width: 100%;
+  height: 100%;
   max-width: 375px;
   margin-bottom: 3rem;
   margin-top: 2rem;

--- a/IFU-Web/src/index.html
+++ b/IFU-Web/src/index.html
@@ -1,13 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>IFUWeb</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <app-root></app-root>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>IFUWeb</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root />
+  </body>
 </html>

--- a/IFU-Web/src/styles.scss
+++ b/IFU-Web/src/styles.scss
@@ -1,1 +1,4 @@
-/* You can add global styles to this file, and also import other style files */
+body {
+  background-color: #e7ebf5;
+  width: auto;
+}


### PR DESCRIPTION
index.html에서 body태그가 내부 본문의 테두리 여백을 발생시키는 것으로 확인됨.

적당한 여백을 두고 있는 현재 레이아웃을 유지하면서
문제가 되는 흰 배경을 제거하기 위해 배경색을 변경함.